### PR TITLE
Make cleaning release names optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const semver = require('semver');
 
 module.exports = (versions, options) => {
 	options = Object.assign({
-		includePrereleases: true
+		includePrereleases: true,
+		clean: true
 	}, options);
 
 	let sortedVersions = versions.filter(x => semver.valid(x)).sort(semver.rcompare);
@@ -12,5 +13,9 @@ module.exports = (versions, options) => {
 		sortedVersions = sortedVersions.filter(x => semver.prerelease(x) === null);
 	}
 
-	return sortedVersions.map(x => semver.clean(x));
+	if (options.clean) {
+		sortedVersions = sortedVersions.map(x => semver.clean(x));
+	}
+
+	return sortedVersions;
 };

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Include prereleases, like `1.2.3-alpha.3`.
 Type: `boolean`<br>
 Default: `true`
 
-Clean release names, e.g. `v1.2.3` -> `1.3.0`.
+Clean versions. For example `v1.3.0` → `1.3.0`.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,13 @@ Default: `true`
 
 Include prereleases, like `1.2.3-alpha.3`.
 
+##### clean
+
+Type: `boolean`<br>
+Default: `true`
+
+Clean release names, e.g. `v1.2.3` -> `1.3.0`.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -48,3 +48,32 @@ test('handles prerelease versions', t => {
 		'1.0.0'
 	]);
 });
+
+test('handles clean release names', t => {
+	const versions = [
+		'v1.3.16',
+		'v1.7.0',
+		'v1.6.9',
+		'v1.6.8',
+		'v1.3.15',
+		'v1.6.7'
+	];
+
+	t.deepEqual(m(versions), [
+		'1.7.0',
+		'1.6.9',
+		'1.6.8',
+		'1.6.7',
+		'1.3.16',
+		'1.3.15'
+	]);
+
+	t.deepEqual(m(versions, {clean: false}), [
+		'v1.7.0',
+		'v1.6.9',
+		'v1.6.8',
+		'v1.6.7',
+		'v1.3.16',
+		'v1.3.15'
+	]);
+});


### PR DESCRIPTION
Adds a `clean` option (default: `true`) so the cleaning of release names can be disabled.
This is needed for https://github.com/sindresorhus/refined-github/pull/395, so please also update the [browserified version](https://gist.github.com/sindresorhus/ae3a8d9275bae19c9f3cfa22c77b8251)